### PR TITLE
Add Django-style path() and include() URL helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ Notes:
 For Sequelize ORM, The Developer will have to run `npx sequelize-cli init` in their project
 
 
+
+### URL helpers (`path` and `include`)
+
+`hormoneJS` now supports Django-like URL declarations via `path()` and `include()` from [`src/url_base.js`](src/url_base.js).
+
+```js
+import { path, include } from "../src/url_base.js";
+import { HomeAPI } from "./views.js";
+
+export const urls = [
+  path("/", HomeAPI, "home"),
+  path("blog/", include("blog"), "blog")
+]
+```
+
+`Url` is still supported for backwards compatibility.
+
 ## Instructions
 
 - Clone the project via `git clone <url> && cd hormoneJS`

--- a/example/testapp/urls.js
+++ b/example/testapp/urls.js
@@ -1,7 +1,6 @@
-import { Url } from "../../src/url_base.js";
+import { path } from "../../src/url_base.js";
 import { TestAPITestApp } from "./views.js";
 
-
 export const urls = [
-    new Url({name: "test", urlPath: "/", routeHandler: TestAPITestApp })
+    path("/", TestAPITestApp, "test")
 ]

--- a/example/urls.js
+++ b/example/urls.js
@@ -1,10 +1,9 @@
-import { Url } from "../src/url_base.js";
-import { TestAPI } from "./views.js"; 
-
+import { include, path } from "../src/url_base.js";
+import { TestAPI } from "./views.js";
 
 export const urls = [
-    new Url({name: "test", urlPath: "/", routeHandler: TestAPI }),
-    new Url({name: "testapp", urlPath: "test/", app: "testapp"})  
+    path("/", TestAPI, "test"),
+    path("test/", include("testapp"), "testapp")
 ]
 
 

--- a/src/url_base.js
+++ b/src/url_base.js
@@ -3,6 +3,26 @@ import { APIWrapper } from "./pre_register.js";
 import { getAppFolderPath } from "./apps-helper.js";
 import path from "path";
 
+const INCLUDE_TYPE = Symbol("include");
+
+function normalizeRouteName(route = "") {
+  const cleaned = route.replace(/\/+$/g, "").replace(/^\/+/g, "");
+  return cleaned.replace(/\//g, "_") || "root";
+}
+
+function getRouteName({ name, urlPath, routeHandler, app }) {
+  if (name) {
+    return name;
+  }
+  if (typeof app === "string") {
+    return app.split(".").pop();
+  }
+  if (routeHandler?.name) {
+    return routeHandler.name;
+  }
+  return normalizeRouteName(urlPath);
+}
+
 export class Url {
   // given url path, get the appropriate app.
   // allowed formats: "appName"
@@ -33,6 +53,31 @@ export class Url {
   // }
 }
 
+export function include(app) {
+  if (typeof app !== "string" || !app.trim()) {
+    throw new Error("include() expects the app dot path as a non-empty string");
+  }
+  return { [INCLUDE_TYPE]: true, app };
+}
+
+export function pathRoute(urlPath, routeHandlerOrInclude, name = undefined) {
+  if (routeHandlerOrInclude?.[INCLUDE_TYPE]) {
+    const app = routeHandlerOrInclude.app;
+    return new Url({
+      name: getRouteName({ name, urlPath, app }),
+      urlPath,
+      app,
+    });
+  }
+  return new Url({
+    name: getRouteName({ name, urlPath, routeHandler: routeHandlerOrInclude }),
+    urlPath,
+    routeHandler: routeHandlerOrInclude,
+  });
+}
+
+export { pathRoute as path };
+
 export async function registerRoutes({express_app, app_path="", urlPrefix=""}) {
   const urls = await dynamicBaseImport(path.join(app_path, "urls.js"), "urls");
 
@@ -60,5 +105,4 @@ export async function registerRoutes({express_app, app_path="", urlPrefix=""}) {
     }
   }
 }
-
 


### PR DESCRIPTION
### Motivation

- Provide a Django-like API for declaring routes (`path` and `include`) to make URL configuration more ergonomic and to address the referenced feature request. 
- Maintain backwards compatibility with existing `Url` objects while enabling nested app inclusion and inferred route names when `name` is omitted.

### Description

- Add `include(appDotPath)` and `path(urlPath, routeHandlerOrInclude, name?)` helpers in `src/url_base.js` (internally implemented as `pathRoute` and exported as `path`) to mirror Django's `include`/`path` semantics.
- Introduce a symbol-based include marker (`INCLUDE_TYPE`), `getRouteName` name-inference logic, and `normalizeRouteName` utility to compute route names when `name` is not provided.
- Keep the existing `Url` class intact and construct `Url` instances from the new helpers so existing registration logic remains unchanged.
- Update example URL files (`example/urls.js`, `example/testapp/urls.js`) to use the new helpers and document usage in `README.md` with a small example.

### Testing

- Ran `node -e "import('./src/url_base.js').then(m=>{ if(typeof m.path!=='function'||typeof m.include!=='function') throw new Error('missing helpers'); const r=m.path('x/', class Demo{}, 'demo'); if(!r?.data?.name) throw new Error('bad path'); const i=m.path('x/', m.include('testapp')); if(!i.app) throw new Error('bad include'); console.log('ok'); })"` and it completed successfully.
- Ran `node -e "import('./example/urls.js').then(m=>{ if(!Array.isArray(m.urls)) throw new Error('urls missing'); console.log(m.urls.length); })"` which succeeded and returned the expected URL count.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad11469f4c832596f16cd85305fc84)